### PR TITLE
Allow for matching with Capybara within blocks

### DIFF
--- a/lib/orderly.rb
+++ b/lib/orderly.rb
@@ -6,7 +6,9 @@ module Orderly
     match do |earlier_content|
       begin
         if within_matcher
-          page.find(within_matcher[:within]).native.inner_html.index(earlier_content) < page.find(within_matcher[:within]).native.inner_html.index(later_content)
+          within within_matcher[:within] do
+            page.body.index(earlier_content) < page.body.index(later_content)
+          end
         else
           page.body.index(earlier_content) < page.body.index(later_content)
         end

--- a/lib/orderly.rb
+++ b/lib/orderly.rb
@@ -2,10 +2,14 @@ require "orderly/version"
 require "rspec/expectations"
 
 module Orderly
-  RSpec::Matchers.define :appear_before do |later_content|
+  RSpec::Matchers.define :appear_before do |later_content, within_matcher|
     match do |earlier_content|
       begin
-        page.body.index(earlier_content) < page.body.index(later_content)
+        if within_matcher
+          page.find(within_matcher[:within]).native.inner_html.index(earlier_content) < page.find(within_matcher[:within]).native.inner_html.index(later_content)
+        else
+          page.body.index(earlier_content) < page.body.index(later_content)
+        end
       rescue ArgumentError
         raise "Could not locate later content on page: #{later_content}"
       rescue NoMethodError

--- a/lib/orderly.rb
+++ b/lib/orderly.rb
@@ -6,9 +6,8 @@ module Orderly
     match do |earlier_content|
       begin
         if within_matcher
-          within within_matcher[:within] do
-            page.body.index(earlier_content) < page.body.index(later_content)
-          end
+          html = Nokogiri::HTML(page.html).search(within_matcher[:within]).to_html
+          html.index(earlier_content) < html.index(later_content)
         else
           page.body.index(earlier_content) < page.body.index(later_content)
         end

--- a/spec/lib/orderly_spec.rb
+++ b/spec/lib/orderly_spec.rb
@@ -38,7 +38,27 @@ describe Orderly do
 
       specify "using a Capybara within block" do
         page.visit "/thisthatthis"
-        expect(that).to appear_before this, within: '.within-block'
+
+        within '.outer-div' do
+          expect(this).to appear_before that
+        end
+
+        within '.outer-div' do
+          expect(that).to_not appear_before this
+        end
+
+        within '.outer-div' do
+          expect(that).to appear_before this, within: '.inner-div'
+        end
+
+        within '.outer-div' do
+          expect(this).to_not appear_before that, within: '.inner-div'
+        end
+
+        expect(this).to appear_before that, within: '.outer-div'
+
+        expect(that).to_not appear_before this, within: '.outer-div'
+
       end
 
     end

--- a/spec/lib/orderly_spec.rb
+++ b/spec/lib/orderly_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'capybara'
 
-describe Orderly, type: :feature do
+describe Orderly do
   let(:this) { "<p>One piece of content</p>" }
   let(:that) { "<p>Another piece of content</p>" }
 

--- a/spec/lib/orderly_spec.rb
+++ b/spec/lib/orderly_spec.rb
@@ -33,6 +33,17 @@ describe Orderly do
       expect { expect(this).to appear_before(that) }.to raise_error error_text
       expect { expect(this).not_to appear_before(that) }.to raise_error error_text
     end
+
+    context 'handling within blocks' do
+
+      specify "using a Capybara within block" do
+        page.visit "/thisthatthis"
+        expect(that).to appear_before this, within: '.within-block'
+        expect(this).to_not appear_before that, within: '.within-block'
+      end
+
+    end
+
   end
 
 end

--- a/spec/lib/orderly_spec.rb
+++ b/spec/lib/orderly_spec.rb
@@ -39,7 +39,6 @@ describe Orderly do
       specify "using a Capybara within block" do
         page.visit "/thisthatthis"
         expect(that).to appear_before this, within: '.within-block'
-        expect(this).to_not appear_before that, within: '.within-block'
       end
 
     end

--- a/spec/lib/orderly_spec.rb
+++ b/spec/lib/orderly_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 require 'capybara'
 
-describe Orderly do
+describe Orderly, type: :feature do
   let(:this) { "<p>One piece of content</p>" }
   let(:that) { "<p>Another piece of content</p>" }
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,7 @@
 
 require 'orderly'
 require 'capybara'
+require 'capybara/rspec' # load rspec 2 support
 require 'test_app'
 
 RSpec.configure do |config|

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,7 +7,6 @@
 
 require 'orderly'
 require 'capybara'
-require 'capybara/rspec' # load rspec 2 support
 require 'test_app'
 
 RSpec.configure do |config|

--- a/spec/test_app.rb
+++ b/spec/test_app.rb
@@ -24,4 +24,7 @@ class TestApp < Sinatra::Base
     this
   end
 
+  get '/thisthatthis' do
+    "#{this} <div class='within-block'> #{that + this} </div>"
+  end
 end

--- a/spec/test_app.rb
+++ b/spec/test_app.rb
@@ -25,6 +25,12 @@ class TestApp < Sinatra::Base
   end
 
   get '/thisthatthis' do
-    "#{this} <div class='within-block'> #{that + this} </div>"
+    "#{that}
+    <div class='outer-div'>
+      #{this}
+      <div class='inner-div'>
+      #{that + this}
+      </div>
+    </div>"
   end
 end


### PR DESCRIPTION
`expect(this).to appear_before that, within: ‘.some-class’`
