### PR TITLE
Adding license information to the gemspec.

### DIFF
--- a/orderly.gemspec
+++ b/orderly.gemspec
@@ -7,6 +7,7 @@ Gem::Specification.new do |gem|
   gem.description   = %q{orderly: an rspec assertion for request specs to assert that one piece of content appears on the page before another.}
   gem.summary       = %q{Assert this is before that}
   gem.homepage      = "https://github.com/jmondo/orderly"
+  gem.license       = "MIT"
 
   gem.files         = `git ls-files`.split($\)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }


### PR DESCRIPTION
Tools like VersionEye are using this information for license compliance analysis. Would be great if the license information would be part of the gemspec.